### PR TITLE
Makes keyword arguments usage compatible w/ Ruby 3

### DIFF
--- a/lib/slack-notifier/util/link_formatter.rb
+++ b/lib/slack-notifier/util/link_formatter.rb
@@ -29,7 +29,7 @@ module Slack
 
         class << self
           def format string, opts={}
-            LinkFormatter.new(string, opts).formatted
+            LinkFormatter.new(string, **opts).formatted
           end
         end
 


### PR DESCRIPTION
In Ruby 3 keyword arguments are completely *decoupled* from positional arguments (see e.g. [ruby-lang.org News](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)).

This fix makes the LinkFormatter compatible again with the new semantics of keyword arguments in Ruby 3.